### PR TITLE
`docs:` Added missing grub dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Install NASM Assembler
 ```
 sudo pacman -Sy nasm
 ```
+Install Grub 
+```
+sudo pacman -Sy grub
+```
 use `Makefile` to build `kernel.iso` target
 ```
 make kernel.iso

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ falcon OS is a basic operating system from scratch aiming to follow Monolithic K
 - C++ Toolchain
 - GNU Make
 - NASM and GAS Assembler
-- Xorriso for ISO image building
+- Xorriso and Grub for ISO image building
 - LLVM tools clang-format, clang-tidy
 - QEMU or Oracle Virtual Box or Bosch
 - Development Environment: Linux (Preffered)


### PR DESCRIPTION
We are using grub-mkrescue to create an iso file. Not everyone has grub installed on their machines